### PR TITLE
Add function for warining added new domains

### DIFF
--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -16,6 +16,7 @@ namespace FlexConfirmMail
         public List<string> TrustedDomains;
         public List<string> UnsafeDomains;
         public List<string> UnsafeFiles;
+        public bool SafeNewDomainsEnabled = true;
         public HashSet<ConfigOption> Modified;
 
         public string TrustedDomainsPattern = "";
@@ -80,6 +81,11 @@ namespace FlexConfirmMail
             if (other.Modified.Contains(ConfigOption.UnsafeFiles))
             {
                 UnsafeFiles.AddRange(other.UnsafeFiles);
+            }
+
+            if (other.Modified.Contains(ConfigOption.SafeNewDomainsEnabled))
+            {
+                SafeNewDomainsEnabled = other.SafeNewDomainsEnabled;
             }
 
             Modified.UnionWith(other.Modified);

--- a/Config/Const.cs
+++ b/Config/Const.cs
@@ -18,6 +18,7 @@ namespace FlexConfirmMail
         MainSkipIfNoExt,
         TrustedDomains,
         UnsafeDomains,
-        UnsafeFiles
+        UnsafeFiles,
+        SafeNewDomainsEnabled,
     }
 }

--- a/Config/Loader.cs
+++ b/Config/Loader.cs
@@ -175,6 +175,16 @@ namespace FlexConfirmMail
                 }
             }
 
+            if (key == "SafeNewDomainsEnabled")
+            {
+                if (ParseBool(val, out b))
+                {
+                    config.SafeNewDomainsEnabled = b;
+                    config.Modified.Add(ConfigOption.SafeNewDomainsEnabled);
+                    return true;
+                }
+            }
+
             return false;
         }
 

--- a/Dialog/ConfigDialog.xaml
+++ b/Dialog/ConfigDialog.xaml
@@ -40,6 +40,7 @@
                                         <TextBox x:Name="SafeBccThreshold" Width="40" VerticalAlignment="center"></TextBox>
                                         <Label Content="{x:Static resx:Resources.ConfigSafeBccThresholdSuffix}"></Label>
                                     </StackPanel>
+                                    <CheckBox x:Name="SafeNewDomainsEnabled" Content="{x:Static resx:Resources.ConfigSafeNewDomainsEnabled}" />
                                 </StackPanel>
                             </StackPanel>
                         </GroupBox>

--- a/Dialog/ConfigDialog.xaml.cs
+++ b/Dialog/ConfigDialog.xaml.cs
@@ -149,6 +149,9 @@ namespace FlexConfirmMail.Dialog
             text += Serialize(ConfigOption.MainSkipIfNoExt,
                               MainSkipIfNoExt.IsChecked,
                               _default.MainSkipIfNoExt);
+            text += Serialize(ConfigOption.SafeNewDomainsEnabled,
+                              SafeNewDomainsEnabled.IsChecked,
+                              _default.SafeNewDomainsEnabled);
             return text;
         }
 

--- a/Dialog/ConfigDialog.xaml.cs
+++ b/Dialog/ConfigDialog.xaml.cs
@@ -36,6 +36,7 @@ namespace FlexConfirmMail.Dialog
             SafeBccEnabled.IsChecked = _config.SafeBccEnabled;
             SafeBccThreshold.Text = _config.SafeBccThreshold.ToString();
             MainSkipIfNoExt.IsChecked = _config.MainSkipIfNoExt;
+            SafeNewDomainsEnabled.IsChecked = _config.SafeNewDomainsEnabled;
 
             // TrustedDomains
             if (_default.Modified.Contains(ConfigOption.TrustedDomains))

--- a/Dialog/MainDialog.xaml.cs
+++ b/Dialog/MainDialog.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;

--- a/FlexConfirmMail.csproj
+++ b/FlexConfirmMail.csproj
@@ -198,7 +198,6 @@
       <DesignTime>True</DesignTime>
     </Compile>
     <None Include="FlexConfirmMail.iss" />
-    <None Include="FlexConfirmMail_3_TemporaryKey.pfx" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -249,10 +248,11 @@
     <SignManifests>true</SignManifests>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestKeyFile>FlexConfirmMail_3_TemporaryKey.pfx</ManifestKeyFile>
+    <ManifestKeyFile>
+    </ManifestKeyFile>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestCertificateThumbprint>9890BBEF56F17434001CDAE60CA5534016A5047C</ManifestCertificateThumbprint>
+    <ManifestCertificateThumbprint>73E7B9D1F72EDA033E7A9D6B17BC37A96CE8513A</ManifestCertificateThumbprint>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>

--- a/FlexConfirmMail.csproj
+++ b/FlexConfirmMail.csproj
@@ -198,6 +198,7 @@
       <DesignTime>True</DesignTime>
     </Compile>
     <None Include="FlexConfirmMail.iss" />
+    <None Include="FlexConfirmMail_3_TemporaryKey.pfx" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -248,11 +249,10 @@
     <SignManifests>true</SignManifests>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestKeyFile>
-    </ManifestKeyFile>
+    <ManifestKeyFile>FlexConfirmMail_3_TemporaryKey.pfx</ManifestKeyFile>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestCertificateThumbprint>73E7B9D1F72EDA033E7A9D6B17BC37A96CE8513A</ManifestCertificateThumbprint>
+    <ManifestCertificateThumbprint>9890BBEF56F17434001CDAE60CA5534016A5047C</ManifestCertificateThumbprint>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -61,12 +61,192 @@ namespace FlexConfirmMail.Properties {
         }
         
         /// <summary>
+        ///   このアドオンについて に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string AboutAddon {
+            get {
+                return ResourceManager.GetString("AboutAddon", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   型 System.Drawing.Bitmap のローカライズされたリソースを検索します。
         /// </summary>
         public static System.Drawing.Bitmap banner {
             get {
                 object obj = ResourceManager.GetObject("banner", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   キャンセル に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string Cancel {
+            get {
+                return ResourceManager.GetString("Cancel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   送信カウントダウン設定 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ConfigCount {
+            get {
+                return ResourceManager.GetString("ConfigCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   カウントダウンのダイアログの「いますぐ送信」ボタンを有効化する に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ConfigCountAllowSkip {
+            get {
+                return ResourceManager.GetString("ConfigCountAllowSkip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   メール送信前のカウントダウンを有効化する に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ConfigCountEnabled {
+            get {
+                return ResourceManager.GetString("ConfigCountEnabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   送信までのカウントダウン秒数: に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ConfigCountSeconds {
+            get {
+                return ResourceManager.GetString("ConfigCountSeconds", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   一般設定 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ConfigGeneral {
+            get {
+                return ResourceManager.GetString("ConfigGeneral", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   宛先が社内ドメインのみの場合は確認をスキップする に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ConfigMainSkipIfNoExt {
+            get {
+                return ResourceManager.GetString("ConfigMainSkipIfNoExt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   その他の設定 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ConfigMisc {
+            get {
+                return ResourceManager.GetString("ConfigMisc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   To/CCに一定数以上のドメインが含まれている場合に警告する に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ConfigSafeBccEnabled {
+            get {
+                return ResourceManager.GetString("ConfigSafeBccEnabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   警告対象となるドメインの数: に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ConfigSafeBccThreshold {
+            get {
+                return ResourceManager.GetString("ConfigSafeBccThreshold", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   件以上 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ConfigSafeBccThresholdSuffix {
+            get {
+                return ResourceManager.GetString("ConfigSafeBccThresholdSuffix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   返信時に新しいドメインが追加されていた場合警告する に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ConfigSafeNewDomainsEnabled {
+            get {
+                return ResourceManager.GetString("ConfigSafeNewDomainsEnabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   社内ドメイン設定 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ConfigTrustedDomains {
+            get {
+                return ResourceManager.GetString("ConfigTrustedDomains", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   注意が必要なドメイン設定 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ConfigUnsafeDomains {
+            get {
+                return ResourceManager.GetString("ConfigUnsafeDomains", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   注意が必要なファイル名設定 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ConfigUnsafeFiles {
+            get {
+                return ResourceManager.GetString("ConfigUnsafeFiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   警告設定 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ConfigWarning {
+            get {
+                return ResourceManager.GetString("ConfigWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   FlexConfirmMail設定 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ConfigWindowTitle {
+            get {
+                return ResourceManager.GetString("ConfigWindowTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   秒後に送信します に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string CountSendInSeconds {
+            get {
+                return ResourceManager.GetString("CountSendInSeconds", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   送信カウントダウン - FlexConfirmMail に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string CountWindowTitle {
+            get {
+                return ResourceManager.GetString("CountWindowTitle", resourceCulture);
             }
         }
         
@@ -79,298 +259,339 @@ namespace FlexConfirmMail.Properties {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
-        public static string RibbonButtonFlexConfirmMail {
-            get {
-                return ResourceManager.GetString("RibbonButtonFlexConfirmMail", resourceCulture);
-            }
-        }
-
-        public static string RibbonGroupFlexConfirmMail {
-            get {
-                return ResourceManager.GetString("RibbonGroupFlexConfirmMail", resourceCulture);
-            }
-        }
-
-        public static string SaveAndQuit {
-            get {
-                return ResourceManager.GetString("SaveAndQuit", resourceCulture);
-            }
-        }
-
-        public static string Cancel {
-            get {
-                return ResourceManager.GetString("Cancel", resourceCulture);
-            }
-        }
-
-        public static string Seconds {
-            get {
-                return ResourceManager.GetString("Seconds", resourceCulture);
-            }
-        }
-
-        public static string ConfigWindowTitle {
-            get {
-                return ResourceManager.GetString("ConfigWindowTitle", resourceCulture);
-            }
-        }
-
-        public static string ConfigGeneral {
-            get {
-                return ResourceManager.GetString("ConfigGeneral", resourceCulture);
-            }
-        }
-
-        public static string ConfigCount {
-            get {
-                return ResourceManager.GetString("ConfigCount", resourceCulture);
-            }
-        }
-
-        public static string ConfigCountEnabled {
-            get {
-                return ResourceManager.GetString("ConfigCountEnabled", resourceCulture);
-            }
-        }
-
-        public static string ConfigCountAllowSkip {
-            get {
-                return ResourceManager.GetString("ConfigCountAllowSkip", resourceCulture);
-            }
-        }
-
-        public static string ConfigCountSeconds {
-            get {
-                return ResourceManager.GetString("ConfigCountSeconds", resourceCulture);
-            }
-        }
-
-        public static string ConfigWarning {
-            get {
-                return ResourceManager.GetString("ConfigWarning", resourceCulture);
-            }
-        }
-
-        public static string ConfigSafeBccEnabled {
-            get {
-                return ResourceManager.GetString("ConfigSafeBccEnabled", resourceCulture);
-            }
-        }
-
-        public static string ConfigSafeBccThreshold {
-            get {
-                return ResourceManager.GetString("ConfigSafeBccThreshold", resourceCulture);
-            }
-        }
-
-        public static string ConfigSafeBccThresholdSuffix {
-            get {
-                return ResourceManager.GetString("ConfigSafeBccThresholdSuffix", resourceCulture);
-            }
-        }
-
-        public static string ConfigMisc {
-            get {
-                return ResourceManager.GetString("ConfigMisc", resourceCulture);
-            }
-        }
-
-        public static string ConfigMainSkipIfNoExt {
-            get {
-                return ResourceManager.GetString("ConfigMainSkipIfNoExt", resourceCulture);
-            }
-        }
-
-        public static string ConfigTrustedDomains {
-            get {
-                return ResourceManager.GetString("ConfigTrustedDomains", resourceCulture);
-            }
-        }
-
-        public static string TrustedDomainsPolicy {
-            get {
-                return ResourceManager.GetString("TrustedDomainsPolicy", resourceCulture);
-            }
-        }
-
-        public static string UnsafeDomainsPolicy{
-            get {
-                return ResourceManager.GetString("UnsafeDomainsPolicy", resourceCulture);
-            }
-        }
-
-        public static string UnsafeFilesPolicy {
-            get {
-                return ResourceManager.GetString("UnsafeFilesPolicy", resourceCulture);
-            }
-        }
-
-        public static string TrustedDomainsExample {
-            get {
-                return ResourceManager.GetString("TrustedDomainsExample", resourceCulture);
-            }
-        }
-
-        public static string UnsafeDomainsExample {
-            get {
-                return ResourceManager.GetString("UnsafeDomainsExample", resourceCulture);
-            }
-        }
-
-        public static string UnsafeFilesExample {
-            get {
-                return ResourceManager.GetString("UnsafeFilesExample", resourceCulture);
-            }
-        }
-
-        public static string TrustedDomainsTemplate {
-            get {
-                return ResourceManager.GetString("TrustedDomainsTemplate", resourceCulture);
-            }
-        }
-
-        public static string UnsafeDomainsTemplate {
-            get {
-                return ResourceManager.GetString("UnsafeDomainsTemplate", resourceCulture);
-            }
-        }
-
-        public static string UnsafeFilesTemplate {
-            get {
-                return ResourceManager.GetString("UnsafeFilesTemplate", resourceCulture);
-            }
-        }
-
-        public static string TrustedDomains {
-            get {
-                return ResourceManager.GetString("TrustedDomains", resourceCulture);
-            }
-        }
-
-        public static string ConfigUnsafeDomains {
-            get {
-                return ResourceManager.GetString("ConfigUnsafeDomains", resourceCulture);
-            }
-        }
-
-        public static string UnsafeDomains {
-            get {
-                return ResourceManager.GetString("UnsafeDomains", resourceCulture);
-            }
-        }
-
-        public static string ConfigUnsafeFiles {
-            get {
-                return ResourceManager.GetString("ConfigUnsafeFiles", resourceCulture);
-            }
-        }
-
-        public static string UnsafeFiles {
-            get {
-                return ResourceManager.GetString("UnsafeFiles", resourceCulture);
-            }
-        }
-
-        public static string AboutAddon {
-            get {
-                return ResourceManager.GetString("AboutAddon", resourceCulture);
-            }
-        }
-
-        public static string TextLog {
-            get {
-                return ResourceManager.GetString("TextLog", resourceCulture);
-            }
-        }
-
-        public static string CountWindowTitle {
-            get {
-                return ResourceManager.GetString("CountWindowTitle", resourceCulture);
-            }
-        }
-
-        public static string CountSendInSeconds {
-            get {
-                return ResourceManager.GetString("CountSendInSeconds", resourceCulture);
-            }
-        }
-
-        public static string Send {
-            get {
-                return ResourceManager.GetString("Send", resourceCulture);
-            }
-        }
-
-        public static string SendNow {
-            get {
-                return ResourceManager.GetString("SendNow", resourceCulture);
-            }
-        }
-
-        public static string MainExternal {
-            get {
-                return ResourceManager.GetString("MainExternal", resourceCulture);
-            }
-        }
-
-        public static string MainUnsafeDomainsWarning {
-            get {
-                return ResourceManager.GetString("MainUnsafeDomainsWarning", resourceCulture);
-            }
-        }
-
-        public static string MainUnsafeDomainsWarningHint {
-            get {
-                return ResourceManager.GetString("MainUnsafeDomainsWarningHint", resourceCulture);
-            }
-        }
-
-        public static string MainUnsafeFilesWarning {
-            get {
-                return ResourceManager.GetString("MainUnsafeFilesWarning", resourceCulture);
-            }
-        }
-
-        public static string MainUnsafeFilesWarningHint {
-            get {
-                return ResourceManager.GetString("MainUnsafeFilesWarningHint", resourceCulture);
-            }
-        }
-
-        public static string MainSafeBccWarning {
-            get {
-                return ResourceManager.GetString("MainSafeBccWarning", resourceCulture);
-            }
-        }
-
-        public static string MainSafeBccWarningHint {
-            get {
-                return ResourceManager.GetString("MainSafeBccWarningHint", resourceCulture);
-            }
-        }
-
-        public static string MainFilesWarning {
-            get {
-                return ResourceManager.GetString("MainFilesWarning", resourceCulture);
-            }
-        }
-
-        public static string MainTrusted {
-            get {
-                return ResourceManager.GetString("MainTrusted", resourceCulture);
-            }
-        }
-
+        
+        /// <summary>
+        ///   一括チェック に類似しているローカライズされた文字列を検索します。
+        /// </summary>
         public static string MainCheckAll {
             get {
                 return ResourceManager.GetString("MainCheckAll", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   外部の送信先 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string MainExternal {
+            get {
+                return ResourceManager.GetString("MainExternal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   添付ファイル／その他の警告 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
         public static string MainFile {
             get {
                 return ResourceManager.GetString("MainFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   [添付ファイル] {0} に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string MainFilesWarning {
+            get {
+                return ResourceManager.GetString("MainFilesWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   [警告] To・Ccに{0}件以上のドメインが含まれています。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string MainSafeBccWarning {
+            get {
+                return ResourceManager.GetString("MainSafeBccWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   宛先に多数のドメインが検知されました。
+        ///ToおよびCcに含まれるメールアドレスはすべての受取人が確認できるため、
+        ///アナウンスなどを一斉送信する場合はBccを利用して宛先リストを隠します。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string MainSafeBccWarningHint {
+            get {
+                return ResourceManager.GetString("MainSafeBccWarningHint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   社内の送信先 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string MainTrusted {
+            get {
+                return ResourceManager.GetString("MainTrusted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   [警告] 注意が必要なドメイン（{0}）が宛先に含まれています。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string MainUnsafeDomainsWarning {
+            get {
+                return ResourceManager.GetString("MainUnsafeDomainsWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   このドメインは誤送信の可能性が高いため、再確認を促す警告を出してします。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string MainUnsafeDomainsWarningHint {
+            get {
+                return ResourceManager.GetString("MainUnsafeDomainsWarningHint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   [警告] 注意が必要なファイル名（{0}）が含まれています。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string MainUnsafeFilesWarning {
+            get {
+                return ResourceManager.GetString("MainUnsafeFilesWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   添付ファイルに注意が必要な単語が含まれているため、
+        ///再確認を促す警告を出しています。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string MainUnsafeFilesWarningHint {
+            get {
+                return ResourceManager.GetString("MainUnsafeFilesWarningHint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   FlexConfirmMail設定 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string RibbonButtonFlexConfirmMail {
+            get {
+                return ResourceManager.GetString("RibbonButtonFlexConfirmMail", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   送信チェック に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string RibbonGroupFlexConfirmMail {
+            get {
+                return ResourceManager.GetString("RibbonGroupFlexConfirmMail", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   保存して閉じる に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SaveAndQuit {
+            get {
+                return ResourceManager.GetString("SaveAndQuit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   秒 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string Seconds {
+            get {
+                return ResourceManager.GetString("Seconds", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   送信 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string Send {
+            get {
+                return ResourceManager.GetString("Send", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   今すぐ送信 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SendNow {
+            get {
+                return ResourceManager.GetString("SendNow", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   動作ログ に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string TextLog {
+            get {
+                return ResourceManager.GetString("TextLog", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   社内ドメイン に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string TrustedDomains {
+            get {
+                return ResourceManager.GetString("TrustedDomains", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   example.com
+        ///-example.org に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string TrustedDomainsExample {
+            get {
+                return ResourceManager.GetString("TrustedDomainsExample", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   # 社内ドメイン設定 ###
+        ///# 組織設定により、社内ドメインとして以下が指定されています。
+        ///#
+        ///# {0}
+        ///#
+        ///# さらにドメインを追加する場合は、以下に1行ずつ入力してください。
+        ///# また、先頭に「-」をつけると、ドメインを除外することができます。
+        ///# 指定にはワイルドカード（*および?）も使用可能です。
+        ///##################################
+        ///
+        ///{1} に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string TrustedDomainsPolicy {
+            get {
+                return ResourceManager.GetString("TrustedDomainsPolicy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   # 社内ドメイン設定 ###
+        ///#
+        ///# (1) 送信時に社内の宛先として扱うドメインを指定します。
+        ///# (2) 以下の例のように一行に一件ずつ記載します。
+        ///# (3) 冒頭が「#」から始まる行は無視されます。
+        ///# (4) 指定にはワイルドカード（*および?）を使用可能です。
+        ///#
+        ///##################################
+        ///
+        ///example.com
+        ///example.org に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string TrustedDomainsTemplate {
+            get {
+                return ResourceManager.GetString("TrustedDomainsTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   注意が必要なドメイン に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string UnsafeDomains {
+            get {
+                return ResourceManager.GetString("UnsafeDomains", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   example.com
+        ///-example.org に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string UnsafeDomainsExample {
+            get {
+                return ResourceManager.GetString("UnsafeDomainsExample", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   # 注意が必要なドメイン設定 ###
+        ///# 組織設定により、注意が必要なドメインとして以下が指定されています。
+        ///#
+        ///# {0}
+        ///#
+        ///# さらにドメインを追加する場合は、以下に1行ずつ入力してください。
+        ///# また、先頭に「-」をつけると、ドメインを除外することができます。
+        ///# 指定にはワイルドカード（*および?）も使用可能です。
+        ///##################################
+        ///
+        ///{1} に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string UnsafeDomainsPolicy {
+            get {
+                return ResourceManager.GetString("UnsafeDomainsPolicy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   # 注意が必要なドメイン設定 ###
+        ///#
+        ///# (1) 送信時に警告対象とする注意ドメインを指定します。
+        ///# (2) 以下の例のように一行に一件ずつ記載します。
+        ///# (3) 冒頭が「#」から始まる行は無視されます。
+        ///# (4) 指定にはワイルドカード（*および?）を使用可能です。
+        ///#
+        ///##################################
+        ///
+        ///example.com
+        ///example.org に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string UnsafeDomainsTemplate {
+            get {
+                return ResourceManager.GetString("UnsafeDomainsTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   注意が必要なファイル名 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string UnsafeFiles {
+            get {
+                return ResourceManager.GetString("UnsafeFiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   社外秘
+        ///-除外キーワード に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string UnsafeFilesExample {
+            get {
+                return ResourceManager.GetString("UnsafeFilesExample", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   # 注意が必要なファイル名設定 ###
+        ///# 組織設定により、注意が必要なファイル名として以下が指定されています。
+        ///#
+        ///# {0}
+        ///#
+        ///# さらにキーワードを追加する場合は、以下に1行ずつ入力してください。
+        ///# また、先頭に「-」をつけると、キーワードを除外することができます。
+        ///# 指定にはワイルドカード（*および?）も使用可能です。
+        ///##################################
+        ///
+        ///{1} に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string UnsafeFilesPolicy {
+            get {
+                return ResourceManager.GetString("UnsafeFilesPolicy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   # 注意が必要なファイル名設定 ###
+        ///#
+        ///# (1) 添付ファイルに含まれる場合に警告する注意ワードを指定します。
+        ///# (2) 以下の例のように一行に一件ずつ記載します。
+        ///# (3) 冒頭が「#」から始まる行は無視されます。
+        ///#
+        ///##################################
+        ///
+        ///社外秘
+        ///機密 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string UnsafeFilesTemplate {
+            get {
+                return ResourceManager.GetString("UnsafeFilesTemplate", resourceCulture);
             }
         }
     }

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -179,7 +179,7 @@ namespace FlexConfirmMail.Properties {
         }
         
         /// <summary>
-        ///   返信時に新しいドメインが追加されていた場合に警告する に類似しているローカライズされた文字列を検索します。
+        ///   返信の宛先に今まで含まれていなかったドメインのアドレスが追加された場合に警告する に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string ConfigSafeNewDomainsEnabled {
             get {

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -179,7 +179,7 @@ namespace FlexConfirmMail.Properties {
         }
         
         /// <summary>
-        ///   返信時に新しいドメインが追加されていた場合警告する に類似しているローカライズされた文字列を検索します。
+        ///   返信時に新しいドメインが追加されていた場合に警告する に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string ConfigSafeNewDomainsEnabled {
             get {

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -233,6 +233,19 @@ namespace FlexConfirmMail.Properties {
         }
         
         /// <summary>
+        ///   返信元のメールの宛先に含まれていなかったドメインの以下の宛先が追加されています。
+        ///
+        ///{0}
+        ///
+        ///送信してよろしいですか？ に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ConfirmNewDomains {
+            get {
+                return ResourceManager.GetString("ConfirmNewDomains", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   秒後に送信します に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string CountSendInSeconds {
@@ -592,6 +605,15 @@ namespace FlexConfirmMail.Properties {
         public static string UnsafeFilesTemplate {
             get {
                 return ResourceManager.GetString("UnsafeFilesTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   警告 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string Warning {
+            get {
+                return ResourceManager.GetString("Warning", resourceCulture);
             }
         }
     }

--- a/Properties/Resources.en.resx
+++ b/Properties/Resources.en.resx
@@ -336,4 +336,7 @@ so please use Bcc when sending an message to unrelated parties.</value>
   <data name="MainFile" xml:space="preserve">
     <value>Attachments / Warnings</value>
   </data>
+  <data name="ConfigSafeNewDomainsEnabled" xml:space="preserve">
+    <value>Warn if new domains are added when replying</value>
+  </data>
 </root>

--- a/Properties/Resources.en.resx
+++ b/Properties/Resources.en.resx
@@ -337,7 +337,7 @@ so please use Bcc when sending an message to unrelated parties.</value>
     <value>Attachments / Warnings</value>
   </data>
   <data name="ConfigSafeNewDomainsEnabled" xml:space="preserve">
-    <value>Warn if new domains are added when replying</value>
+    <value>Confirm when any recipients with domains different from any existing recipients are added</value>
   </data>
   <data name="ConfirmNewDomains" xml:space="preserve">
     <value>There are recipients with domains not included in the recipients of the original message.

--- a/Properties/Resources.en.resx
+++ b/Properties/Resources.en.resx
@@ -339,4 +339,14 @@ so please use Bcc when sending an message to unrelated parties.</value>
   <data name="ConfigSafeNewDomainsEnabled" xml:space="preserve">
     <value>Warn if new domains are added when replying</value>
   </data>
+  <data name="ConfirmNewDomains" xml:space="preserve">
+    <value>There are recipients with domains not included in the recipients of the original message.
+
+{0}
+
+Do you really want to send this message?</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>Warning</value>
+  </data>
 </root>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -339,4 +339,14 @@ ToおよびCcに含まれるメールアドレスはすべての受取人が確�
   <data name="ConfigSafeNewDomainsEnabled" xml:space="preserve">
     <value>返信時に新しいドメインが追加されていた場合に警告する</value>
   </data>
+  <data name="ConfirmNewDomains" xml:space="preserve">
+    <value>返信元のメールの宛先に含まれていなかったドメインの以下の宛先が追加されています。
+
+{0}
+
+送信してよろしいですか？</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>警告</value>
+  </data>
 </root>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -336,4 +336,7 @@ ToおよびCcに含まれるメールアドレスはすべての受取人が確�
   <data name="MainFile" xml:space="preserve">
     <value>添付ファイル／その他の警告</value>
   </data>
+  <data name="ConfigSafeNewDomainsEnabled" xml:space="preserve">
+    <value>返信時に新しいドメインが追加されていた場合警告する</value>
+  </data>
 </root>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -337,6 +337,6 @@ ToおよびCcに含まれるメールアドレスはすべての受取人が確�
     <value>添付ファイル／その他の警告</value>
   </data>
   <data name="ConfigSafeNewDomainsEnabled" xml:space="preserve">
-    <value>返信時に新しいドメインが追加されていた場合警告する</value>
+    <value>返信時に新しいドメインが追加されていた場合に警告する</value>
   </data>
 </root>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -337,7 +337,7 @@ ToおよびCcに含まれるメールアドレスはすべての受取人が確�
     <value>添付ファイル／その他の警告</value>
   </data>
   <data name="ConfigSafeNewDomainsEnabled" xml:space="preserve">
-    <value>返信時に新しいドメインが追加されていた場合に警告する</value>
+    <value>返信の宛先に今まで含まれていなかったドメインのアドレスが追加された場合に警告する</value>
   </data>
   <data name="ConfirmNewDomains" xml:space="preserve">
     <value>返信元のメールの宛先に含まれていなかったドメインの以下の宛先が追加されています。

--- a/Properties/Resources.zh.resx
+++ b/Properties/Resources.zh.resx
@@ -334,14 +334,14 @@ example.org</value>
     <value>附件 / 警告</value>
   </data>
   <data name="ConfigSafeNewDomainsEnabled" xml:space="preserve">
-    <value>Warn if new domains are added when replying</value>
+    <value>回复时如果添加新域则发出警告</value>
   </data>
   <data name="ConfirmNewDomains" xml:space="preserve">
-    <value>There are recipients with domains not included in the recipients of the original message.
+    <value>有些收件人的域未包含在原始邮件的收件人中。
 
 {0}
 
-Do you really want to send this message?</value>
+您真的要发送此消息吗？</value>
   </data>
   <data name="Warning" xml:space="preserve">
     <value>警告</value>

--- a/Properties/Resources.zh.resx
+++ b/Properties/Resources.zh.resx
@@ -336,4 +336,14 @@ example.org</value>
   <data name="ConfigSafeNewDomainsEnabled" xml:space="preserve">
     <value>Warn if new domains are added when replying</value>
   </data>
+  <data name="ConfirmNewDomains" xml:space="preserve">
+    <value>There are recipients with domains not included in the recipients of the original message.
+
+{0}
+
+Do you really want to send this message?</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>警告</value>
+  </data>
 </root>

--- a/Properties/Resources.zh.resx
+++ b/Properties/Resources.zh.resx
@@ -334,7 +334,7 @@ example.org</value>
     <value>附件 / 警告</value>
   </data>
   <data name="ConfigSafeNewDomainsEnabled" xml:space="preserve">
-    <value>回复时如果添加新域则发出警告</value>
+    <value>确认何时添加域与现有收件人不同的任何收件人</value>
   </data>
   <data name="ConfirmNewDomains" xml:space="preserve">
     <value>有些收件人的域未包含在原始邮件的收件人中。

--- a/Properties/Resources.zh.resx
+++ b/Properties/Resources.zh.resx
@@ -334,14 +334,14 @@ example.org</value>
     <value>附件 / 警告</value>
   </data>
   <data name="ConfigSafeNewDomainsEnabled" xml:space="preserve">
-    <value>确认何时添加域与现有收件人不同的任何收件人</value>
+    <value>Confirm when any recipients with domains different from any existing recipients are added</value>
   </data>
   <data name="ConfirmNewDomains" xml:space="preserve">
-    <value>有些收件人的域未包含在原始邮件的收件人中。
+    <value>There are recipients with domains not included in the recipients of the original message.
 
 {0}
 
-您真的要发送此消息吗？</value>
+Do you really want to send this message?</value>
   </data>
   <data name="Warning" xml:space="preserve">
     <value>警告</value>

--- a/Properties/Resources.zh.resx
+++ b/Properties/Resources.zh.resx
@@ -333,4 +333,7 @@ example.org</value>
   <data name="MainFile" xml:space="preserve">
     <value>附件 / 警告</value>
   </data>
+  <data name="ConfigSafeNewDomainsEnabled" xml:space="preserve">
+    <value>Warn if new domains are added when replying</value>
+  </data>
 </root>

--- a/ThisAddIn.cs
+++ b/ThisAddIn.cs
@@ -3,6 +3,7 @@ using System.Windows.Forms;
 using System.Windows.Media;
 using System.Windows.Interop;
 using Outlook = Microsoft.Office.Interop.Outlook;
+using System;
 
 namespace FlexConfirmMail
 {

--- a/ThisAddIn.cs
+++ b/ThisAddIn.cs
@@ -104,14 +104,6 @@ namespace FlexConfirmMail
         private void ThisAddIn_ItemSend(object Item, ref bool Cancel)
         {
             Outlook.MailItem mail = (Outlook.MailItem)Item;
-            Outlook.Folder folder = mail.Parent as Outlook.Folder;
-            Outlook.Store store = folder.Store;
-            if (store.IsConversationEnabled)
-            {
-                // Obtain a Conversation object.
-                Outlook.Conversation conv =
-                    mail.GetConversation();
-            }
 
             // Some users reported that Intel Graphic + Win10 causes
             // a blank screen. Diable Hardware Accerelation.

--- a/ThisAddIn.cs
+++ b/ThisAddIn.cs
@@ -3,8 +3,6 @@ using System.Windows.Forms;
 using System.Windows.Media;
 using System.Windows.Interop;
 using Outlook = Microsoft.Office.Interop.Outlook;
-using System;
-using System.Runtime.InteropServices;
 using System.Collections.Generic;
 
 namespace FlexConfirmMail

--- a/policy/FlexConfirmMailDefault.admx
+++ b/policy/FlexConfirmMailDefault.admx
@@ -112,5 +112,17 @@
         <multiText id="UnsafeFiles" valueName="UnsafeFiles"/>
       </elements>
     </policy>
+    <policy name="SafeNewDomainsEnabled" valueName="SafeNewDomainsEnabled"
+        displayName="$(string.SafeNewDomainsEnabled)" class="Machine"
+        key="SOFTWARE\Policies\FlexConfirmMail\Default">
+      <parentCategory ref="FlexConfirmMailDefault"/>
+      <supportedOn ref="SUPPORTED_NotSpecified"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
   </policies>
 </policyDefinitions>

--- a/policy/en-US/FlexConfirmMailDefault.adml
+++ b/policy/en-US/FlexConfirmMailDefault.adml
@@ -17,7 +17,7 @@
       <string id="UnsafeDomains_Explain">Set the list of domains to show an "unsafe recipient" warning. Wildcards (* and ?) are available.</string>
       <string id="UnsafeFiles">Configure Unsafe files</string>
       <string id="UnsafeFiles_Explain">Set the list of keywords to show an "unsafe filename" warning. Wildcards (* and ?) are available.</string>
-      <string id="SafeNewDomainsEnabled">Warn if new domains are added when replying</string>
+      <string id="SafeNewDomainsEnabled">Confirm when any recipients with domains different from any existing recipients are added</string>
     </stringTable>
     <presentationTable>
       <presentation id="CountSeconds">

--- a/policy/en-US/FlexConfirmMailDefault.adml
+++ b/policy/en-US/FlexConfirmMailDefault.adml
@@ -17,6 +17,7 @@
       <string id="UnsafeDomains_Explain">Set the list of domains to show an "unsafe recipient" warning. Wildcards (* and ?) are available.</string>
       <string id="UnsafeFiles">Configure Unsafe files</string>
       <string id="UnsafeFiles_Explain">Set the list of keywords to show an "unsafe filename" warning. Wildcards (* and ?) are available.</string>
+      <string id="SafeNewDomainsEnabled">Warn if new domains are added when replying</string>
     </stringTable>
     <presentationTable>
       <presentation id="CountSeconds">

--- a/policy/ja-JP/FlexConfirmMailDefault.adml
+++ b/policy/ja-JP/FlexConfirmMailDefault.adml
@@ -17,7 +17,7 @@
       <string id="UnsafeDomains_Explain">送信時に警告対象とする注意ドメインを指定します。指定にはワイルドカード（*および?）を使用可能です。</string>
       <string id="UnsafeFiles">注意が必要なファイル名設定</string>
       <string id="UnsafeFiles_Explain">添付ファイルに含まれる場合に警告する注意ワードを指定します。指定にはワイルドカード（*および?）を使用可能です。</string>
-      <string id="SafeNewDomainsEnabled">To/Ccに一定数以上のドメインが含まれている場合に警告する</string>
+      <string id="SafeNewDomainsEnabled">返信時に新しいドメインが追加されていた場合に警告する</string>
     </stringTable>
     <presentationTable>
       <presentation id="CountSeconds">

--- a/policy/ja-JP/FlexConfirmMailDefault.adml
+++ b/policy/ja-JP/FlexConfirmMailDefault.adml
@@ -17,6 +17,7 @@
       <string id="UnsafeDomains_Explain">送信時に警告対象とする注意ドメインを指定します。指定にはワイルドカード（*および?）を使用可能です。</string>
       <string id="UnsafeFiles">注意が必要なファイル名設定</string>
       <string id="UnsafeFiles_Explain">添付ファイルに含まれる場合に警告する注意ワードを指定します。指定にはワイルドカード（*および?）を使用可能です。</string>
+      <string id="SafeNewDomainsEnabled">To/Ccに一定数以上のドメインが含まれている場合に警告する</string>
     </stringTable>
     <presentationTable>
       <presentation id="CountSeconds">

--- a/policy/ja-JP/FlexConfirmMailDefault.adml
+++ b/policy/ja-JP/FlexConfirmMailDefault.adml
@@ -17,7 +17,7 @@
       <string id="UnsafeDomains_Explain">送信時に警告対象とする注意ドメインを指定します。指定にはワイルドカード（*および?）を使用可能です。</string>
       <string id="UnsafeFiles">注意が必要なファイル名設定</string>
       <string id="UnsafeFiles_Explain">添付ファイルに含まれる場合に警告する注意ワードを指定します。指定にはワイルドカード（*および?）を使用可能です。</string>
-      <string id="SafeNewDomainsEnabled">返信時に新しいドメインが追加されていた場合に警告する</string>
+      <string id="SafeNewDomainsEnabled">返信の宛先に今まで含まれていなかったドメインのアドレスが追加された場合に警告する</string>
     </stringTable>
     <presentationTable>
       <presentation id="CountSeconds">

--- a/policy/zh-CN/FlexConfirmMailDefault.adml
+++ b/policy/zh-CN/FlexConfirmMailDefault.adml
@@ -17,7 +17,7 @@
       <string id="UnsafeDomains_Explain">设置要被提醒的域。 Wildcards (* and ?) are available.</string>
       <string id="UnsafeFiles">设置不安全的文件名</string>
       <string id="UnsafeFiles_Explain">为附件设置警告关键字。 Wildcards (* and ?) are available.</string>
-      <string id="SafeNewDomainsEnabled">Warn if new domains are added when replying</string>
+      <string id="SafeNewDomainsEnabled">回复时如果添加新域则发出警告</string>
     </stringTable>
     <presentationTable>
       <presentation id="CountSeconds">

--- a/policy/zh-CN/FlexConfirmMailDefault.adml
+++ b/policy/zh-CN/FlexConfirmMailDefault.adml
@@ -17,6 +17,7 @@
       <string id="UnsafeDomains_Explain">设置要被提醒的域。 Wildcards (* and ?) are available.</string>
       <string id="UnsafeFiles">设置不安全的文件名</string>
       <string id="UnsafeFiles_Explain">为附件设置警告关键字。 Wildcards (* and ?) are available.</string>
+      <string id="SafeNewDomainsEnabled">Warn if new domains are added when replying</string>
     </stringTable>
     <presentationTable>
       <presentation id="CountSeconds">

--- a/policy/zh-CN/FlexConfirmMailDefault.adml
+++ b/policy/zh-CN/FlexConfirmMailDefault.adml
@@ -17,7 +17,7 @@
       <string id="UnsafeDomains_Explain">设置要被提醒的域。 Wildcards (* and ?) are available.</string>
       <string id="UnsafeFiles">设置不安全的文件名</string>
       <string id="UnsafeFiles_Explain">为附件设置警告关键字。 Wildcards (* and ?) are available.</string>
-      <string id="SafeNewDomainsEnabled">回复时如果添加新域则发出警告</string>
+      <string id="SafeNewDomainsEnabled">确认何时添加域与现有收件人不同的任何收件人</string>
     </stringTable>
     <presentationTable>
       <presentation id="CountSeconds">

--- a/policy/zh-CN/FlexConfirmMailDefault.adml
+++ b/policy/zh-CN/FlexConfirmMailDefault.adml
@@ -17,7 +17,7 @@
       <string id="UnsafeDomains_Explain">设置要被提醒的域。 Wildcards (* and ?) are available.</string>
       <string id="UnsafeFiles">设置不安全的文件名</string>
       <string id="UnsafeFiles_Explain">为附件设置警告关键字。 Wildcards (* and ?) are available.</string>
-      <string id="SafeNewDomainsEnabled">确认何时添加域与现有收件人不同的任何收件人</string>
+      <string id="SafeNewDomainsEnabled">Confirm when any recipients with domains different from any existing recipients are added</string>
     </stringTable>
     <presentationTable>
       <presentation id="CountSeconds">


### PR DESCRIPTION

* The new setting `SafeNewDomainsEnabled`(返信の宛先に今まで含まれていなかったドメインのアドレスが追加された場合に警告する) is added. 
* Warnings are enabled for emails created with Reply button or ReplyAll button.
* Data for Warnings for already created reply emails are refreshed after restarting Outlook.
  * This means that after restarting Outlook, even if we restart from a draft, no warning will be displayed.
* A Warning dialog is displayed if new domains have been added.

![image](https://github.com/FlexConfirmMail/Outlook/assets/15982708/02afd39d-cb81-4f23-9079-d6e89e682be4)

![image](https://github.com/FlexConfirmMail/Outlook/assets/15982708/ae14fbba-9a33-4697-8817-06dd3608af06)